### PR TITLE
Simplify query

### DIFF
--- a/_episodes/07-join.md
+++ b/_episodes/07-join.md
@@ -279,16 +279,15 @@ SELECT rowid, * FROM Person;
  > >
  > > ~~~
  > > SELECT
- > >   DISTINCT Site.site_name
+ > >   DISTINCT Visit.site_name
  > > FROM
- > >   Site
- > >   JOIN Visit
+ > >   Visit
  > >   JOIN Measurement
- > >   JOIN Person ON Site.site_name = Visit.site_name
- > >   AND Visit.visit_id = Measurement.visit_id
- > >   AND Measurement.person_id = Person.person_id
- > > WHERE
- > >   Person.personal_name = 'Frank';
+ > >   JOIN Person ON
+ > >     Visit.visit_id = Measurement.visit_id
+ > >     AND Measurement.person_id = Person.person_id
+ > >   WHERE
+ > >     Person.personal_name = 'Frank';
  > > ~~~
  > > {: .sql}
  > >


### PR DESCRIPTION
Use three tables instead of four in exercise query, removing an unneeded join.